### PR TITLE
Fix: Notification tap always routes to last backup done

### DIFF
--- a/app/src/main/java/de/lolhens/resticui/BackupManager.kt
+++ b/app/src/main/java/de/lolhens/resticui/BackupManager.kt
@@ -63,7 +63,7 @@ class BackupManager private constructor(context: Context) {
     ) {
         fun pendingIntent() = PendingIntent.getActivity(
             context,
-            0,
+            System.currentTimeMillis().toInt(),
             FolderActivity.intent(context, false, folderConfigId),
             PendingIntent.FLAG_UPDATE_CURRENT
         )


### PR DESCRIPTION
Bug: tapping on a Restic notification always opens the folder of the last backup done instead of the specific folder of the tapped notification