### PR TITLE
Bugfix for "non-primary" external storage provider folder uris.

### DIFF
--- a/app/src/main/java/de/lolhens/resticui/util/ASFUriHelper.java
+++ b/app/src/main/java/de/lolhens/resticui/util/ASFUriHelper.java
@@ -7,9 +7,17 @@ import android.net.Uri;
 import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
+import androidx.documentfile.provider.DocumentFile;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
 // https://gist.github.com/asifmujteba/d89ba9074bc941de1eaa#file-asfurihelper
 public class ASFUriHelper {
+
+    private static final List<String> documentUriTypes = Arrays.asList(Environment.DIRECTORY_MUSIC, Environment.DIRECTORY_PODCASTS, Environment.DIRECTORY_RINGTONES, Environment.DIRECTORY_ALARMS, Environment.DIRECTORY_NOTIFICATIONS, Environment.DIRECTORY_PICTURES, Environment.DIRECTORY_MOVIES, Environment.DIRECTORY_DOWNLOADS, Environment.DIRECTORY_DCIM, Environment.DIRECTORY_DOCUMENTS);
+
     public static String getPath(final Context context, final Uri uri) {
         if (DocumentsContract.isDocumentUri(context, uri)) { // DocumentProvider
             if (isExternalStorageDocument(uri)) { // ExternalStorageProvider
@@ -23,9 +31,24 @@ public class ASFUriHelper {
                     } else {
                         return Environment.getExternalStorageDirectory() + "/";
                     }
+                } else {
+                    final DocumentFile documentUriRoot = DocumentFile.fromTreeUri(context, DocumentsContract.buildTreeDocumentUri(
+                            uri.getAuthority(), type + ":"));
+                    if (documentUriRoot != null && documentUriRoot.exists() && ASFUriHelper.documentUriTypes.contains(documentUriRoot.getName())) {
+                        final String basePath = Environment.getExternalStoragePublicDirectory(documentUriRoot.getName()).getAbsolutePath();
+                        final String fullPath;
+                        if (split.length > 1)
+                            fullPath = basePath + "/" + split[1];
+                        else {
+                            fullPath = basePath + "/";
+                        }
+                        if (new File(fullPath).exists()) {
+                            return fullPath;
+                        }
+                    }
+
                 }
 
-                // TODO handle non-primary volumes
             } else if (isDownloadsDocument(uri)) { // DownloadsProvider
                 try {
                     final Uri contentUri = ContentUris.withAppendedId(

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:7.4.0-beta02'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.0-beta02'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Implemented a fix to support non "primary" external storage document provider uris  like "home:" for the "documents" folder.

### Fixed Issue / How to reproduce: 
1. Create a folder "Documents" under "storage/emulated/0" ( under Android 9 or 10 - for example on the android emulator)
2. Try to define this folder as a Backup folder
3. Crash 
```
java.lang.NullPointerException: path must not be null
	at de.lolhens.resticui.util.DirectoryChooser$Companion$DefaultDirectoryChooser.register$lambda$0(DirectoryChooser.kt:48)
	at de.lolhens.resticui.util.DirectoryChooser$Companion$DefaultDirectoryChooser.$r8$lambda$jK8O1H1CKL7PB9Zkehlu4Bw5Rh0(Unknown Source:0)
	at de.lolhens.resticui.util.DirectoryChooser$Companion$DefaultDirectoryChooser$$ExternalSyntheticLambda0.onActivityResult(Unknown Source:6)
	at androidx.activity.result.ActivityResultRegistry$1.onStateChanged(ActivityResultRegistry.java:149)
	at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.java:360)
	at androidx.lifecycle.LifecycleRegistry.forwardPass(LifecycleRegistry.java:271)
	at androidx.lifecycle.LifecycleRegistry.sync(LifecycleRegistry.java:313)
	at androidx.lifecycle.LifecycleRegistry.moveToState(LifecycleRegistry.java:151)
	at androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent(LifecycleRegistry.java:134)
	at androidx.fragment.app.Fragment.performStart(Fragment.java:3167)
	at androidx.fragment.app.FragmentStateManager.start(FragmentStateManager.java:588)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:279)
	at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:113)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1433)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2977)
	at androidx.fragment.app.FragmentManager.dispatchStart(FragmentManager.java:2902)
	at androidx.fragment.app.Fragment.performStart(Fragment.java:3171)
	at androidx.fragment.app.FragmentStateManager.start(FragmentStateManager.java:588)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:279)
	at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:113)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1433)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2977)
	at androidx.fragment.app.FragmentManager.dispatchStart(FragmentManager.java:2902)
	at androidx.fragment.app.FragmentController.dispatchStart(FragmentController.java:274)
	at androidx.fragment.app.FragmentActivity.onStart(FragmentActivity.java:359)
	at androidx.appcompat.app.AppCompatActivity.onStart(AppCompatActivity.java:251)
	at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1433)
	at android.app.Activity.performStart(Activity.java:7924)
	at android.app.ActivityThread.handleStartActivity(ActivityThread.java:3332)
	at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:221)
	at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:201)
	at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:173)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2044)
	at android.os.Handler.dispatchMessage(Handler.java:107)
	at android.os.Looper.loop(Looper.java:224)
	at android.app.ActivityThread.main(ActivityThread.java:7560)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:539)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)

```

The content uri looks like the this: `content://com.android.externalstorage.documents/tree/home%3A/document/home%3A` and causes the issue.