### PR TITLE
Update ResticRepo.kt

### DIFF
--- a/app/src/main/java/de/lolhens/resticui/restic/ResticRepo.kt
+++ b/app/src/main/java/de/lolhens/resticui/restic/ResticRepo.kt
@@ -133,7 +133,8 @@ abstract class ResticRepo(
                 "--json",
                 "backup",
                 "--host",
-                restic.hostname
+                restic.hostname,
+                "--exclude=/storage/emulated/0/Android"
             ).plus(
                 paths.map { it.absolutePath }
             ),


### PR DESCRIPTION
Added exclude flag to backup /storage/emulated/0/ removing the error for not being able to read into Android folder. (Temporary fix)